### PR TITLE
Support K8s v1.22

### DIFF
--- a/docs/deployment/bases/namespaced/skipper-hpa/deployment.yaml
+++ b/docs/deployment/bases/namespaced/skipper-hpa/deployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: skipper-ingress
   labels:
     application: skipper-ingress
-    version: v0.13.44
+    version: v0.13.204
     component: ingress
 spec:
   strategy:
@@ -18,7 +18,7 @@ spec:
       name: skipper-ingress
       labels:
         application: skipper-ingress
-        version: v0.13.44
+        version: v0.13.204
         component: ingress
     spec:
       priorityClassName: system-cluster-critical
@@ -26,7 +26,7 @@ spec:
       dnsPolicy: ClusterFirstWithHostNet
       containers:
         - name: skipper-ingress
-          image: registry.opensource.zalan.do/teapot/skipper:v0.13.44
+          image: registry.opensource.zalan.do/teapot/skipper:v0.13.204
           ports:
             - name: ingress-port
               containerPort: 9999
@@ -65,6 +65,7 @@ spec:
             - "-write-timeout-server=2m"
             - "-response-header-timeout-backend=2m"
             - "-timeout-backend=2m"
+            - "-kubernetes-ingress-v1"
           readinessProbe:
             httpGet:
               path: /kube-system/healthz

--- a/docs/deployment/bases/namespaced/skipper-hpa/serviceaccount.yaml
+++ b/docs/deployment/bases/namespaced/skipper-hpa/serviceaccount.yaml
@@ -10,13 +10,13 @@ metadata:
   name: skipper-ingress
 rules:
   - apiGroups:
-      - extensions
+      - networking.k8s.io
     resources:
       - ingresses
     verbs:
       - get
       - list
-  - apiGroups: [ "" ]
+  - apiGroups: [""]
     resources:
       - namespaces
       - services

--- a/docs/deployment/overlays/1-namespaced-hpa/shinyproxy/shinyproxy.yaml
+++ b/docs/deployment/overlays/1-namespaced-hpa/shinyproxy/shinyproxy.yaml
@@ -40,11 +40,11 @@ spec:
       - id: 01_hello
         display-name: Hello Application
         description: Application which demonstrates the basics of a Shiny app
-        container-cmd: [ "R", "-e", "shinyproxy::run_01_hello()" ]
+        container-cmd: ["R", "-e", "shinyproxy::run_01_hello()"]
         container-image: openanalytics/shinyproxy-demo
-        access-groups: [ scientists, mathematicians ]
+        access-groups: [scientists, mathematicians]
       - id: 06_tabsets
-        container-cmd: [ "R", "-e", "shinyproxy::run_06_tabsets()" ]
+        container-cmd: ["R", "-e", "shinyproxy::run_06_tabsets()"]
         container-image: openanalytics/shinyproxy-demo
         access-groups: scientists
       - id: rstudio
@@ -54,7 +54,7 @@ spec:
         port: 8787
         container-env:
           DISABLE_AUTH: true
-          WWW_ROOT_PATH: "#{proxySpec.containerSpecs[0].env.get('SHINYPROXY_PUBLIC_PATH')}"
+          WWW_ROOT_PATH: "#{proxy.getRuntimeValue('SHINYPROXY_PUBLIC_PATH')}"
   kubernetesPodTemplateSpecPatches: |
     - op: add
       path: /spec/containers/0/env/-

--- a/pom.xml
+++ b/pom.xml
@@ -1,12 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>eu.openanalytics</groupId>
     <artifactId>shinyproxy-operator</artifactId>
-    <version>1.0.3</version>
+    <version>1.1.0</version>
 
     <organization>
         <name>Open Analytics NV</name>
@@ -17,11 +16,11 @@
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.release>11</maven.compiler.release>
         <maven.compiler.target>11</maven.compiler.target>
-        <version.fabric8.client>5.7.3</version.fabric8.client>
+        <version.fabric8.client>5.8.0</version.fabric8.client>
         <kotlin.version>1.5.20</kotlin.version>
         <kotlin.compiler.incremental>true</kotlin.compiler.incremental>
         <junit.jupiter.version>5.6.0</junit.jupiter.version>
-        <log4j.version>2.17.0</log4j.version>
+        <log4j.version>2.17.1</log4j.version>
     </properties>
 
     <distributionManagement>

--- a/src/main/kotlin/eu/openanalytics/shinyproxyoperator/Operator.kt
+++ b/src/main/kotlin/eu/openanalytics/shinyproxyoperator/Operator.kt
@@ -150,12 +150,12 @@ class Operator(client: NamespacedKubernetesClient? = null,
             replicaSetListener = ResourceListener(sendChannel, this.client.inAnyNamespace().apps().replicaSets())
             serviceListener = ResourceListener(sendChannel, this.client.inAnyNamespace().services())
             configMapListener = ResourceListener(sendChannel, this.client.inAnyNamespace().configMaps())
-            ingressController = IngressController(sendChannel, this.client, this.client.inAnyNamespace().network().ingress())
+            ingressController = IngressController(sendChannel, this.client, this.client.inAnyNamespace().network().v1().ingresses())
         } else {
             replicaSetListener = ResourceListener(sendChannel, this.client.inNamespace(namespace).apps().replicaSets())
             serviceListener = ResourceListener(sendChannel, this.client.inNamespace(namespace).services())
             configMapListener = ResourceListener(sendChannel, this.client.inNamespace(namespace).configMaps())
-            ingressController = IngressController(sendChannel, this.client, this.client.inNamespace(namespace).network().ingress())
+            ingressController = IngressController(sendChannel, this.client, this.client.inNamespace(namespace).network().v1().ingresses())
         }
     }
 

--- a/src/main/kotlin/eu/openanalytics/shinyproxyoperator/controller/ResourceRetriever.kt
+++ b/src/main/kotlin/eu/openanalytics/shinyproxyoperator/controller/ResourceRetriever.kt
@@ -23,7 +23,7 @@ package eu.openanalytics.shinyproxyoperator.controller
 import io.fabric8.kubernetes.api.model.ConfigMap
 import io.fabric8.kubernetes.api.model.Service
 import io.fabric8.kubernetes.api.model.apps.ReplicaSet
-import io.fabric8.kubernetes.api.model.networking.v1beta1.Ingress
+import io.fabric8.kubernetes.api.model.networking.v1.Ingress
 import io.fabric8.kubernetes.client.informers.cache.Lister
 import mu.KotlinLogging
 

--- a/src/main/kotlin/eu/openanalytics/shinyproxyoperator/ingress/skipper/IngressController.kt
+++ b/src/main/kotlin/eu/openanalytics/shinyproxyoperator/ingress/skipper/IngressController.kt
@@ -28,8 +28,8 @@ import eu.openanalytics.shinyproxyoperator.crd.ShinyProxy
 import eu.openanalytics.shinyproxyoperator.crd.ShinyProxyInstance
 import eu.openanalytics.shinyproxyoperator.ingres.IIngressController
 import io.fabric8.kubernetes.api.model.apps.ReplicaSet
-import io.fabric8.kubernetes.api.model.networking.v1beta1.Ingress
-import io.fabric8.kubernetes.api.model.networking.v1beta1.IngressList
+import io.fabric8.kubernetes.api.model.networking.v1.Ingress
+import io.fabric8.kubernetes.api.model.networking.v1.IngressList
 import io.fabric8.kubernetes.client.KubernetesClient
 import io.fabric8.kubernetes.client.dsl.MixedOperation
 import io.fabric8.kubernetes.client.dsl.Resource

--- a/src/main/kotlin/eu/openanalytics/shinyproxyoperator/ingress/skipper/IngressFactory.kt
+++ b/src/main/kotlin/eu/openanalytics/shinyproxyoperator/ingress/skipper/IngressFactory.kt
@@ -26,9 +26,9 @@ import eu.openanalytics.shinyproxyoperator.components.ResourceNameFactory
 import eu.openanalytics.shinyproxyoperator.crd.ShinyProxy
 import eu.openanalytics.shinyproxyoperator.crd.ShinyProxyInstance
 import io.fabric8.kubernetes.api.model.apps.ReplicaSet
-import io.fabric8.kubernetes.api.model.networking.v1beta1.HTTPIngressPath
-import io.fabric8.kubernetes.api.model.networking.v1beta1.HTTPIngressPathBuilder
-import io.fabric8.kubernetes.api.model.networking.v1beta1.IngressBuilder
+import io.fabric8.kubernetes.api.model.networking.v1.HTTPIngressPath
+import io.fabric8.kubernetes.api.model.networking.v1.HTTPIngressPathBuilder
+import io.fabric8.kubernetes.api.model.networking.v1.IngressBuilder
 import io.fabric8.kubernetes.client.KubernetesClient
 import mu.KotlinLogging
 
@@ -37,6 +37,7 @@ class IngressFactory(private val kubeClient: KubernetesClient) {
     private val logger = KotlinLogging.logger {}
 
     fun createOrReplaceIngress(shinyProxy: ShinyProxy, shinyProxyInstance: ShinyProxyInstance, replicaSet: ReplicaSet) {
+
         val hashOfSpec = shinyProxyInstance.hashOfSpec
 
         val isLatest = shinyProxyInstance.isLatestInstance
@@ -101,7 +102,7 @@ class IngressFactory(private val kubeClient: KubernetesClient) {
                     .addNewRule()
                         .withHost(shinyProxy.fqdn)
                         .withNewHttp()
-                            .addToPaths(createPath(shinyProxy, shinyProxyInstance))
+                            .addToPaths(createPathV1(shinyProxy, shinyProxyInstance))
                         .endHttp()
                     .endRule()
                 .endSpec()
@@ -109,23 +110,28 @@ class IngressFactory(private val kubeClient: KubernetesClient) {
         //@formatter:on
 
         val createdIngress =
-            kubeClient.network().ingress().inNamespace(shinyProxy.metadata.namespace).createOrReplace(ingressDefinition)
+            kubeClient.network().v1().ingresses().inNamespace(shinyProxy.metadata.namespace).createOrReplace(ingressDefinition)
         logger.debug { "${shinyProxy.logPrefix(shinyProxyInstance)} [Component/Ingress] Created ${createdIngress.metadata.name} [latest=$isLatest]" }
     }
 
-    private fun createPath(shinyProxy: ShinyProxy, shinyProxyInstance: ShinyProxyInstance): HTTPIngressPath {
+    private fun createPathV1 (shinyProxy: ShinyProxy, shinyProxyInstance: ShinyProxyInstance): HTTPIngressPath {
         //@formatter:off
         val builder = HTTPIngressPathBuilder()
+                .withPathType("Prefix")
                 .withNewBackend()
-                    .withServiceName(ResourceNameFactory.createNameForService(shinyProxy, shinyProxyInstance))
-                    .withNewServicePort()
-                        .withIntVal(80)
-                    .endServicePort()
+                    .withNewService()
+                        .withName(ResourceNameFactory.createNameForService(shinyProxy, shinyProxyInstance))
+                        .withNewPort()
+                            .withNumber(80)
+                        .endPort()
+                    .endService()
                 .endBackend()
         //@formatter:on
 
         if (shinyProxy.subPath != "") {
             builder.withPath(shinyProxy.subPath)
+        } else {
+            builder.withPath("/")
         }
 
         return builder.build()

--- a/src/main/kotlin/eu/openanalytics/shinyproxyoperator/ingress/skipper/IngressListener.kt
+++ b/src/main/kotlin/eu/openanalytics/shinyproxyoperator/ingress/skipper/IngressListener.kt
@@ -27,8 +27,8 @@ import eu.openanalytics.shinyproxyoperator.crd.ShinyProxy
 import eu.openanalytics.shinyproxyoperator.isInManagedNamespace
 import io.fabric8.kubernetes.api.model.HasMetadata
 import io.fabric8.kubernetes.api.model.OwnerReference
-import io.fabric8.kubernetes.api.model.networking.v1beta1.Ingress
-import io.fabric8.kubernetes.api.model.networking.v1beta1.IngressList
+import io.fabric8.kubernetes.api.model.networking.v1.Ingress
+import io.fabric8.kubernetes.api.model.networking.v1.IngressList
 import io.fabric8.kubernetes.client.KubernetesClient
 import io.fabric8.kubernetes.client.dsl.MixedOperation
 import io.fabric8.kubernetes.client.dsl.Resource

--- a/src/test/kotlin/eu/openanalytics/shinyproxyoperator/MainIntegrationTest.kt
+++ b/src/test/kotlin/eu/openanalytics/shinyproxyoperator/MainIntegrationTest.kt
@@ -83,7 +83,7 @@ class MainIntegrationTest : IntegrationTestBase() {
                     assertEquals(0, stableClient.services().list().items.size)
 
                     // -> Ingress should not yet be created
-                    assertEquals(0, stableClient.network().ingresses().list().items.size)
+                    assertEquals(0, stableClient.network().v1().ingresses().list().items.size)
 
                     // -> Latest marker should not yet be set
                     val sp = spTestInstance.retrieveInstance()
@@ -197,7 +197,7 @@ class MainIntegrationTest : IntegrationTestBase() {
 
             // 8. Delete Ingress -> reconcile -> assert it is still ok
             executeAsyncAfter100ms {
-                stableClient.network().ingress()
+                stableClient.network().v1().ingresses()
                     .withName("sp-${sp.metadata.name}-ing-${spTestInstance.hash}".take(63)).delete()
                 logger.info { "Deleted Ingress" }
             }
@@ -660,7 +660,7 @@ class MainIntegrationTest : IntegrationTestBase() {
         spTestInstance.assertServiceIsCorrect(sp)
 
         // d. check ingress
-        val ingresses = namespacedClient.inNamespace(namespace).network().ingresses().list().items
+        val ingresses = namespacedClient.inNamespace(namespace).network().v1().ingresses().list().items
         assertEquals(1, ingresses.size)
         val ingress = ingresses.firstOrNull { it.metadata.labels[LabelFactory.INSTANCE_LABEL] == spTestInstance.hash }
         assertNotNull(ingress)
@@ -704,8 +704,8 @@ class MainIntegrationTest : IntegrationTestBase() {
         assertEquals(1, rule.http.paths.size)
         val path = rule.http.paths[0]
         assertNotNull(path)
-        assertEquals("sp-${sp.metadata.name}-svc-${spTestInstance.hash}".take(63), path.backend.serviceName)
-        assertEquals(IntOrString(80), path.backend.servicePort)
+        assertEquals("sp-${sp.metadata.name}-svc-${spTestInstance.hash}".take(63), path.backend.service.name)
+        assertEquals(80, path.backend.service.port.number)
     }
 
     @Test
@@ -733,7 +733,7 @@ class MainIntegrationTest : IntegrationTestBase() {
         spTestInstance.waitForOneReconcile()
 
         // 4. assert correctness of ingress
-        val ingresses = namespacedClient.inNamespace(namespace).network().ingresses().list().items
+        val ingresses = namespacedClient.inNamespace(namespace).network().v1().ingresses().list().items
         assertEquals(1, ingresses.size)
         val ingress = ingresses.firstOrNull { it.metadata.labels[LabelFactory.INSTANCE_LABEL] == spTestInstance.hash }
         assertNotNull(ingress)
@@ -1053,7 +1053,7 @@ class MainIntegrationTest : IntegrationTestBase() {
         assertEquals(false, sp.status.instances[0].isLatestInstance)
 
         // C) at this point the ingress should not exist yet
-        var ingresses = stableClient.inNamespace(namespace).network().ingresses().list().items
+        var ingresses = stableClient.inNamespace(namespace).network().v1().ingresses().list().items
         assertEquals(0, ingresses.size)
 
         // Test starts here:
@@ -1069,7 +1069,7 @@ class MainIntegrationTest : IntegrationTestBase() {
         assertEquals(true, sp.status.instances[0].isLatestInstance)
 
         // B) at this point the ingress should exist
-        ingresses = stableClient.inNamespace(namespace).network().ingresses().list().items
+        ingresses = stableClient.inNamespace(namespace).network().v1().ingresses().list().items
         assertEquals(1, ingresses.size)
 
     }
@@ -1080,7 +1080,7 @@ class MainIntegrationTest : IntegrationTestBase() {
     fun `operator should properly handle 409 conflicts by replacing the resource`() =
         setup(Mode.NAMESPACED) { namespace, shinyProxyClient, namespacedClient, stableClient, operator, reconcileListener ->
             // 1. create conflicting resources
-            stableClient.load(this.javaClass.getResourceAsStream("/configs/conflict.yaml")).createOrReplace()
+            stableClient.load(this.javaClass.getResourceAsStream("/configs/conflict_v1_ingress.yaml")).createOrReplace()
 
             // 2. create a SP instance
             val spTestInstance = ShinyProxyTestInstance(

--- a/src/test/kotlin/eu/openanalytics/shinyproxyoperator/helpers/ShinyProxyTestInstance.kt
+++ b/src/test/kotlin/eu/openanalytics/shinyproxyoperator/helpers/ShinyProxyTestInstance.kt
@@ -79,7 +79,7 @@ class ShinyProxyTestInstance(private val namespace: String,
     }
 
     fun assertIngressIsCorrect(sp: ShinyProxy, numInstancesRunning: Int = 1, isLatest: Boolean = true) {
-        val ingresses = client.inNamespace(namespace).network().ingresses().list().items
+        val ingresses = client.inNamespace(namespace).network().v1().ingresses().list().items
         assertEquals(numInstancesRunning, ingresses.size)
         val ingress = ingresses.firstOrNull { it.metadata.labels[LabelFactory.INSTANCE_LABEL] == hash }
         assertNotNull(ingress)
@@ -132,8 +132,8 @@ class ShinyProxyTestInstance(private val namespace: String,
         assertEquals(1, rule.http.paths.size)
         val path = rule.http.paths[0]
         assertNotNull(path)
-        assertEquals("sp-${sp.metadata.name}-svc-${hash}".take(63), path.backend.serviceName)
-        assertEquals(IntOrString(80), path.backend.servicePort)
+        assertEquals("sp-${sp.metadata.name}-svc-${hash}".take(63), path.backend.service.name)
+        assertEquals(80, path.backend.service.port.number)
 
     }
 

--- a/src/test/resources/configs/conflict_v1_ingress.yaml
+++ b/src/test/resources/configs/conflict_v1_ingress.yaml
@@ -1,0 +1,41 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: sp-example-shinyproxy-cm-abfc24c726e9e87ea7c633384f2a6599352490
+  namespace: itest
+data:
+  application.yml: |
+    myconfig: test
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: sp-example-shinyproxy-svc-abfc24c726e9e87ea7c633384f2a659935249
+  namespace: itest
+spec:
+  type: ClusterIP
+  ports:
+    - name: http
+      port: 80
+      targetPort: http
+      protocol: TCP
+  selector:
+    app.kubernetes.io/name: myname
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: sp-example-shinyproxy-ing-abfc24c726e9e87ea7c633384f2a659935249
+  namespace: itest
+spec:
+  rules:
+    - host: my-host-name
+      http:
+        paths:
+          - path: /
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: my-service-name
+                port:
+                  number: 8081


### PR DESCRIPTION
As per Issue #30 - the current version does not support Kubernetes V1.22 due to the removal of the v1beta1 Ingress API. 

I have upgraded the Fabric8 library to version `5.8.0`. I am happy to upgrade further, this was just the first version to support k8s v1.22 and I did not want to complicate my life fixing unrelated issues :-) 

I have tested this against my k8s cluster (AWS EKS v1.22) and all the tests are passing. I have also deployed the operator and can confirm the examples are all working.

The gitlab actions tests will probably fail though because they run against older versions of k8s and the updates will not support some versions.