### PR TITLE
Add kubernetesServicePatches to shinyproxy definition

### DIFF
--- a/src/main/kotlin/eu/openanalytics/shinyproxyoperator/components/ServiceFactory.kt
+++ b/src/main/kotlin/eu/openanalytics/shinyproxyoperator/components/ServiceFactory.kt
@@ -34,10 +34,12 @@ class ServiceFactory(private val serviceClient: MixedOperation<Service, ServiceL
 
     private val logger = KotlinLogging.logger {}
 
+    private val servicePatcher = ServicePatcher()
+
     fun create(shinyProxy: ShinyProxy, latestShinyProxyInstance: ShinyProxyInstance) {
         val labels = LabelFactory.labelsForShinyProxy(shinyProxy).toMutableMap()
         labels[LabelFactory.LATEST_INSTANCE_LABEL] = latestShinyProxyInstance.hashOfSpec
-
+        
         //@formatter:off
         val serviceDefinition: Service = ServiceBuilder()
                 .withNewMetadata()
@@ -63,7 +65,8 @@ class ServiceFactory(private val serviceClient: MixedOperation<Service, ServiceL
                 .build()
         //@formatter:on
 
-        val createdService = serviceClient.inNamespace(shinyProxy.metadata.namespace).resource(serviceDefinition).createOrReplace()
+        val patchedService = servicePatcher.patch(serviceDefinition, shinyProxy.parsedServicePatches)
+        val createdService = serviceClient.inNamespace(shinyProxy.metadata.namespace).resource(patchedService).createOrReplace()
         logger.debug { "${shinyProxy.logPrefix(latestShinyProxyInstance)} [Component/Service] Created ${createdService.metadata.name}" }
     }
 

--- a/src/main/kotlin/eu/openanalytics/shinyproxyoperator/components/ServicePatcher.kt
+++ b/src/main/kotlin/eu/openanalytics/shinyproxyoperator/components/ServicePatcher.kt
@@ -1,0 +1,71 @@
+/**
+ * ShinyProxy-Operator
+ *
+ * Copyright (C) 2021-2023 Open Analytics
+ *
+ * ===========================================================================
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Apache License as published by
+ * The Apache Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * Apache License for more details.
+ *
+ * You should have received a copy of the Apache License
+ * along with this program.  If not, see <http://www.apache.org/licenses/>
+ */
+package eu.openanalytics.shinyproxyoperator.components
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory
+import com.fasterxml.jackson.datatype.jsr353.JSR353Module
+import io.fabric8.kubernetes.api.model.HTTPGetAction
+import io.fabric8.kubernetes.api.model.IntOrString
+import io.fabric8.kubernetes.api.model.PodTemplateSpec
+import io.fabric8.kubernetes.api.model.Service
+import io.fabric8.kubernetes.api.model.ServicePort
+import mu.KotlinLogging
+import javax.json.JsonPatch
+import javax.json.JsonStructure
+
+class ServicePatcher {
+    private val mapper = ObjectMapper(YAMLFactory())
+    private val logger = KotlinLogging.logger { }
+
+    init {
+        mapper.registerModule(JSR353Module())
+    }
+
+    /**
+     * Applies a JsonPatch to the given Ingress.
+     */
+    fun patch(service: Service, patch: JsonPatch?): Service {
+        if (patch == null) {
+            return service
+        }
+
+        logger.debug { "Original Service (before applying patches): ${mapper.writeValueAsString(service)}" }
+
+        // 1. convert Service to javax.json.JsonValue object.
+        // This conversion does not actually convert to a string, but some internal
+        // representation of Jackson.
+        val podAsJsonValue: JsonStructure = mapper.convertValue(service, JsonStructure::class.java)
+        // 2. apply patch
+        val patchedPodAsJsonValue: JsonStructure = patch.apply(podAsJsonValue)
+        // 3. convert back to a Service
+        val patchedService = mapper.convertValue(patchedPodAsJsonValue, Service::class.java)
+
+        for (port in patchedService.spec.ports) {
+            port.setTargetPort(IntOrString(port.targetPort.strVal.toIntOrNull()))
+        }
+
+        logger.debug { "Patched Service (after applying patches): ${mapper.writeValueAsString(patchedService)}" }
+
+        return patchedService
+    }
+
+}

--- a/src/main/kotlin/eu/openanalytics/shinyproxyoperator/crd/ShinyProxy.kt
+++ b/src/main/kotlin/eu/openanalytics/shinyproxyoperator/crd/ShinyProxy.kt
@@ -139,6 +139,23 @@ class ShinyProxy : CustomResource<JsonNode, ShinyProxyStatus>(), Namespaced {
     }
 
     @get:JsonIgnore
+    val parsedServicePatches: JsonPatch? by lazy {
+        if (spec.get("kubernetesServicePatches")?.isTextual == true) {
+            try {
+                // convert the raw YAML string into a JsonPatch
+                val yamlReader = ObjectMapper(YAMLFactory())
+                yamlReader.registerModule(JSR353Module())
+                return@lazy yamlReader.readValue(spec.get("kubernetesServicePatches").textValue(), JsonPatch::class.java)
+            } catch (exception: Exception) {
+                exception.printStackTrace() // log the exception for easier debugging
+                throw exception
+            }
+
+        }
+        return@lazy null
+    }
+
+    @get:JsonIgnore
     val subPath: String by lazy {
         if (spec.get("server")?.get("servlet")?.get("context-path")?.isTextual == true) {
             val path = spec.get("server").get("servlet").get("context-path").textValue()


### PR DESCRIPTION
Needed to add annotations to the service created by shinyproxy operator, so I copied the logic of IngressPatch to be able to patch the service definition